### PR TITLE
Fixed a class cast exception when calling serverDidSendError

### DIFF
--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -180,7 +180,7 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
         
         if let delegate = delegate {
             DispatchQueue.main.async(execute: {
-                delegate.serverDidSendError(client: self, withErrorMessage: error as! String, detailedErrorMessage: error as? String)
+                delegate.serverDidSendError(client: self, withErrorMessage: error!.localizedDescription, detailedErrorMessage: error!.localizedDescription)
             })
         }
     }


### PR DESCRIPTION
When the library tries to call the delegate it is casting an Error object into a String causing a class cast exception. The fix calls the error detail methods that deliver Strings. 