### PR TITLE
Close socket connection on disconnect

### DIFF
--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -423,5 +423,6 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
         var headerToSend = [String: String]()
         headerToSend[StompCommands.commandDisconnect] = String(Int(NSDate().timeIntervalSince1970))
         sendFrame(command: StompCommands.commandDisconnect, header: headerToSend, body: nil)
+        socket?.close()
     }
 }


### PR DESCRIPTION
Hey @WrathChaos 

We found that during disconnect, the socket stays open. Is there a reason for that?

In our case it was causing some issues for backend, seems it needed not only `DISCONNECT` frame but also actually closing the socket to recognize it (in our case some behavior is different for socket opened/closed).

Anyway, I though you might find this useful, in our case just calling `socket?.close()` helped.