### PR TITLE
Added 'akaStringBody' parameter to stompClient didReceiveMessage...

### DIFF
--- a/Example/StompClientLib.swift
+++ b/Example/StompClientLib.swift
@@ -58,7 +58,7 @@ public enum StompAckMode {
 
 // Fundamental Protocols
 public protocol StompClientLibDelegate {
-    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, withHeader header:[String:String]?, withDestination destination: String)
+    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, akaStringBody stringBody: String?, withHeader header:[String:String]?, withDestination destination: String)
     
     func stompClientDidDisconnect(client: StompClientLib!)
     func stompClientDidConnect(client: StompClientLib!)
@@ -298,7 +298,7 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
             // Response
             if let delegate = delegate {
                 DispatchQueue.main.async(execute: {
-                    delegate.stompClient(client: self, didReceiveMessageWithJSONBody: self.dictForJSONString(jsonStr: body), withHeader: headers, withDestination: self.destinationFromHeader(header: headers))
+                    delegate.stompClient(client: self, didReceiveMessageWithJSONBody: self.dictForJSONString(jsonStr: body), akaStringBody: body, withHeader: headers, withDestination: self.destinationFromHeader(header: headers))
                 })
             }
         } else if command == StompCommands.responseFrameReceipt {   //

--- a/Example/StompClientLib/ViewController.swift
+++ b/Example/StompClientLib/ViewController.swift
@@ -49,9 +49,10 @@ class ViewController: UIViewController, StompClientLibDelegate {
         print("Socket is Disconnected")
     }
     
-    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, withHeader header: [String : String]?, withDestination destination: String) {
+    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, akaStringBody stringBody: String?, withHeader header: [String : String]?, withDestination destination: String) {
         print("DESTIONATION : \(destination)")
         print("JSON BODY : \(String(describing: jsonBody))")
+        print("STRING BODY : \(stringBody ?? "nil")")
     }
     
     func stompClientJSONBody(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: String?, withHeader header: [String : String]?, withDestination destination: String) {

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ print("Socket is Disconnected")
 
 Your json message will be converted to JSON Body as AnyObject and you will receive your message in this function
 ```ruby
-func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, withHeader header: [String : String]?, withDestination destination: String) {
+func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, akaStringBody stringBody: String?, withHeader header: [String : String]?, withDestination destination: String) {
 print("Destination : \(destination)")
 print("JSON Body : \(String(describing: jsonBody))")
+print("String Body : \(stringBody ?? "nil")")
 }
 ```
 

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -58,7 +58,7 @@ public enum StompAckMode {
 
 // Fundamental Protocols
 public protocol StompClientLibDelegate {
-    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, withHeader header:[String:String]?, withDestination destination: String)
+    func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, akaStringBody stringBody: String?, withHeader header:[String:String]?, withDestination destination: String)
     
     func stompClientDidDisconnect(client: StompClientLib!)
     func stompClientDidConnect(client: StompClientLib!)
@@ -296,7 +296,7 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
             // Response
             if let delegate = delegate {
                 DispatchQueue.main.async(execute: {
-                    delegate.stompClient(client: self, didReceiveMessageWithJSONBody: self.dictForJSONString(jsonStr: body), withHeader: headers, withDestination: self.destinationFromHeader(header: headers))
+                    delegate.stompClient(client: self, didReceiveMessageWithJSONBody: self.dictForJSONString(jsonStr: body), akaStringBody: body, withHeader: headers, withDestination: self.destinationFromHeader(header: headers))
                 })
             }
         } else if command == StompCommands.responseFrameReceipt {   //


### PR DESCRIPTION
It would be good to have a way of receiving the messages' text as it was received - not all stomp messages are JSON, after all, and sometimes users (me) want to be able to use the messages' text verbatim.  I've added a parameter to the `didReceiveMessageWithJSONBody` method: `akaStringBody stringBody: String?` which just passes along `body`.  You should probably test this - my app currently isn't in a state where I can test whether the change worked.  It appears to compile, though, and the change was simple enough that it would be difficult to mess up - I only added a parameter.