### PR TITLE
Fixed ACK header and added one more ACK type

### DIFF
--- a/StompClientLib.podspec
+++ b/StompClientLib.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.name             = 'DTStompClientLib'
   s.version          = '1.3.5'
   s.summary          = 'Simple STOMP Client library. Swift 3, 4, 4.2, 5 compatible'
-  s.swift_version = '4.0', '4.2', '5.0'
+  s.swift_version = '4.0'
 
 # This description is used to generate tags and improve search results.
 #   * Think: What does it do? Why did you write it? What is the focus?

--- a/StompClientLib.podspec
+++ b/StompClientLib.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.name             = 'StompClientLib'
+  s.name             = 'DTStompClientLib'
   s.version          = '1.3.5'
   s.summary          = 'Simple STOMP Client library. Swift 3, 4, 4.2, 5 compatible'
   s.swift_version = '4.0', '4.2', '5.0'
@@ -22,11 +22,11 @@ Pod::Spec.new do |s|
 Simple STOMP Client library, Swift 3, 4, 4.2, 5 compatible. STOMP Protocol let the program subscribe or unsubscribe the topic. It connects the websocket and use the STOMP protocol to subscribe the topic and recieve the message, receipt or even a ping.
                        DESC
 
-  s.homepage         = 'https://github.com/wrathchaos/StompClientLib'
+  s.homepage         = 'https://github.com/rodmytro/StompClientLib'
   # s.screenshots    = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'FreakyCoder' => 'kurayogun@gmail.com' }
-  s.source           = { :git => 'https://github.com/wrathchaos/StompClientLib.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/rodmytro/StompClientLib.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/freakycodercom'
 
   s.ios.deployment_target = '9.0'

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -25,6 +25,7 @@ struct StompCommands {
     static let controlChar = String(format: "%C", arguments: [0x00])
     
     // Ack Mode
+    static let ackClientIndividual = "client-individual"
     static let ackClient = "client"
     static let ackAuto = "auto"
     // Header Commands
@@ -35,7 +36,7 @@ struct StompCommands {
     static let commandHeaderContentType = "content-type"
     static let commandHeaderAck = "ack"
     static let commandHeaderTransaction = "transaction"
-    static let commandHeaderMessageId = "message-id"
+    static let commandHeaderMessageId = "id"
     static let commandHeaderSubscription = "subscription"
     static let commandHeaderDisconnected = "disconnected"
     static let commandHeaderHeartBeat = "heart-beat"
@@ -54,6 +55,7 @@ struct StompCommands {
 public enum StompAckMode {
     case AutoMode
     case ClientMode
+    case ClientIndividualMode
 }
 
 // Fundamental Protocols
@@ -376,6 +378,9 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
         switch ackMode {
         case StompAckMode.ClientMode:
             ack = StompCommands.ackClient
+            break
+        case StompAckMode.ClientIndividaulMode:
+            ack = StompCommands.ackClientIndividual
             break
         default:
             ack = StompCommands.ackAuto


### PR DESCRIPTION
**1)** According to the official documentation `message-id` header from `ACK` frame should be renamed to the `id`.
> The ACK frame MUST include an id header matching the ack header of the MESSAGE being acknowledged.
https://stomp.github.io/stomp-specification-1.2.html#ACK

**2)** Added the `client-individual` type of Acknowledge
> The valid values for the ack header are auto, client, or client-individual.
https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE_ack_Header