### PR TITLE
Fixed ACK id header and added new ACK type

### DIFF
--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -25,6 +25,7 @@ struct StompCommands {
     static let controlChar = String(format: "%C", arguments: [0x00])
     
     // Ack Mode
+    static let ackClientIndividual = "client-individual"
     static let ackClient = "client"
     static let ackAuto = "auto"
     // Header Commands
@@ -35,7 +36,7 @@ struct StompCommands {
     static let commandHeaderContentType = "content-type"
     static let commandHeaderAck = "ack"
     static let commandHeaderTransaction = "transaction"
-    static let commandHeaderMessageId = "message-id"
+    static let commandHeaderMessageId = "id"
     static let commandHeaderSubscription = "subscription"
     static let commandHeaderDisconnected = "disconnected"
     static let commandHeaderHeartBeat = "heart-beat"
@@ -54,6 +55,7 @@ struct StompCommands {
 public enum StompAckMode {
     case AutoMode
     case ClientMode
+    case ClientIndividualMode
 }
 
 // Fundamental Protocols
@@ -376,6 +378,9 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
         switch ackMode {
         case StompAckMode.ClientMode:
             ack = StompCommands.ackClient
+            break
+        case StompAckMode.ClientIndividaulMode:
+            ack = StompCommands.ackClientIndividual
             break
         default:
             ack = StompCommands.ackAuto

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -379,7 +379,7 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
         case StompAckMode.ClientMode:
             ack = StompCommands.ackClient
             break
-        case StompAckMode.ClientIndividaulMode:
+        case StompAckMode.ClientIndividualMode:
             ack = StompCommands.ackClientIndividual
             break
         default:


### PR DESCRIPTION
**1)** According to the official documentation `message-id` header from ACK frame should be renamed to the id.
> The ACK frame MUST include an id header matching the ack header of the MESSAGE being acknowledged.
https://stomp.github.io/stomp-specification-1.2.html#ACK

**2)** Added the client-individual type of Acknowledge
> The valid values for the ack header are auto, client, or client-individual.
https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE_ack_Header