### PR TITLE
Feature/custom queue

### DIFF
--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -80,9 +80,10 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
     private let queue: DispatchQueue
 
     /**
-     All callbacks are run on `queue`.  `queue` should be a serial queue (the default), or undefined behavior may occur.
+     All callbacks are run on `queue`.  `queue` should be a serial queue (the default mode), or undefined behavior may occur.
+     `queue` defaults to `DispatchQueue.main`.
      */
-    public init(queue: DispatchQueue) {
+    public init(queue: DispatchQueue = DispatchQueue.main) {
         self.queue = queue
     }
     


### PR DESCRIPTION
Here's a fix for #92 .  I added an init param for a DispatchQueue, replaced all the `DispatchQueue.main` references with `queue`, and set the SocketRocket queue to `queue` (from its default of the main queue).  It's not been _extensively_ tested, but code that worked before appears to still work with these changes in place.  The main option coming to mind that I might have missed is if, in the same way that SocketRocket used the main queue by default, there were some other component used by StompClientLib that used the main queue by default, and I didn't notice it.  But...I didn't notice any such thing, haha.