### PR TITLE
Adding Objective-C attributes to delegate and main class to turn Objective-C runtime accessible to Nativescript

### DIFF
--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -59,6 +59,7 @@ public enum StompAckMode {
 }
 
 // Fundamental Protocols
+@objc
 public protocol StompClientLibDelegate: class {
     func stompClient(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: AnyObject?, akaStringBody stringBody: String?, withHeader header:[String:String]?, withDestination destination: String)
     
@@ -69,6 +70,7 @@ public protocol StompClientLibDelegate: class {
     func serverDidSendPing()
 }
 
+@objcMembers
 public class StompClientLib: NSObject, SRWebSocketDelegate {
     var socket: SRWebSocket?
     var sessionId: String?


### PR DESCRIPTION
Hey Team, we have a project which needs to connect through WebSocket with STOMP protocol for Nativescript applications;
But to Nativescript be able to access Swift classes it needs to be able to access the Objective-C runtime. So in order to achieve it I've changed the StompClientLib  and added the @objc attribute annotation to StompClientLibDelegate and @objcMembers to StompClientLib, so these classes and its attributes/methods and etc can be access from Nativescript. 

Please, review this code and let me know if these changes will not affecting any other project that use this library.
Looking forward to have these changes approved 👍 
Thanks.