### PR TITLE
Correct README minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Your json message will be converted to JSON Body as AnyObject and you will recei
 
 ```swift
 func stompClientJSONBody(client: StompClientLib!, didReceiveMessageWithJSONBody jsonBody: String?, withHeader header: [String : String]?, withDestination destination: String) {
-  print("DESTIONATION : \(destination)")
+  print("DESTINATION : \(destination)")
   print("String JSON BODY : \(String(describing: jsonBody))")
 }
 ```


### PR DESCRIPTION
This PR contains only 1 minor change in README (spelling of word `destination`)

Hope this PR isn't too nit-picky, just noticed the error while reading the docs so thought I'd drop a quick PR 😊