### PR TITLE
add websocketOpen receivedHTTPHeader callback delegate

### DIFF
--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -201,12 +201,10 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
     public func webSocketDidOpen(_ webSocket: SRWebSocket!) {
         print("WebSocket is connected")
         
-        if let header = CFHTTPMessageCopyAllHeaderFields(webSocket.receivedHTTPHeaders)?.takeUnretainedValue() as? [String:Any] {
-            if let delegate = delegate {
+        if let header = CFHTTPMessageCopyAllHeaderFields(webSocket.receivedHTTPHeaders)?.takeUnretainedValue() as? [String:Any], delegate = delegate {
                 DispatchQueue.main.async(execute: {
                     delegate.StompClientDidOpen(client: self, withHeader: header)
                 })
-            }
         }
         
         connect()

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -66,7 +66,7 @@ public protocol StompClientLibDelegate: class {
     
     func stompClientDidDisconnect(client: StompClientLib!)
     func stompClientDidConnect(client: StompClientLib!)
-    func StompClientDidOpen(client: StompClientLib!, withHeader: [String: Any]?)
+    func StompClientDidOpen(client: StompClientLib!, withHeader: [String: Any])
     func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String)
     func serverDidSendError(client: StompClientLib!, withErrorMessage description: String, detailedErrorMessage message: String?)
     func serverDidSendPing()

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -66,7 +66,7 @@ public protocol StompClientLibDelegate: class {
     
     func stompClientDidDisconnect(client: StompClientLib!)
     func stompClientDidConnect(client: StompClientLib!)
-    func StompClientDidOpen(client: StompClientLib!, header: [String: Any]?)
+    func StompClientDidOpen(client: StompClientLib!, withHeader: [String: Any]?)
     func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String)
     func serverDidSendError(client: StompClientLib!, withErrorMessage description: String, detailedErrorMessage message: String?)
     func serverDidSendPing()
@@ -201,10 +201,10 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
     public func webSocketDidOpen(_ webSocket: SRWebSocket!) {
         print("WebSocket is connected")
         
-        if let json = CFHTTPMessageCopyAllHeaderFields(webSocket.receivedHTTPHeaders)?.takeUnretainedValue() as? [String:Any] {
+        if let header = CFHTTPMessageCopyAllHeaderFields(webSocket.receivedHTTPHeaders)?.takeUnretainedValue() as? [String:Any] {
             if let delegate = delegate {
                 DispatchQueue.main.async(execute: {
-                    delegate.StompClientDidOpen(client: self, header: json)
+                    delegate.StompClientDidOpen(client: self, withHeader: header)
                 })
             }
         }

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -69,6 +69,7 @@ public protocol StompClientLibDelegate: class {
     func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String)
     func serverDidSendError(client: StompClientLib!, withErrorMessage description: String, detailedErrorMessage message: String?)
     func serverDidSendPing()
+    func websocketDidConnect(header: [String: Any]?)
 }
 
 @objcMembers
@@ -198,6 +199,15 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
     
     public func webSocketDidOpen(_ webSocket: SRWebSocket!) {
         print("WebSocket is connected")
+        
+        if let json = CFHTTPMessageCopyAllHeaderFields(webSocket.receivedHTTPHeaders)?.takeUnretainedValue() as? [String:Any] {
+            if let delegate = delegate {
+                DispatchQueue.main.async(execute: {
+                    delegate.websocketDidConnect(header: json)
+                })
+            }
+        }
+        
         connect()
     }
     

--- a/StompClientLib/Classes/StompClientLib.swift
+++ b/StompClientLib/Classes/StompClientLib.swift
@@ -66,10 +66,11 @@ public protocol StompClientLibDelegate: class {
     
     func stompClientDidDisconnect(client: StompClientLib!)
     func stompClientDidConnect(client: StompClientLib!)
+    func StompClientDidOpen(client: StompClientLib!, header: [String: Any]?)
     func serverDidSendReceipt(client: StompClientLib!, withReceiptId receiptId: String)
     func serverDidSendError(client: StompClientLib!, withErrorMessage description: String, detailedErrorMessage message: String?)
     func serverDidSendPing()
-    func websocketDidConnect(header: [String: Any]?)
+   
 }
 
 @objcMembers
@@ -203,7 +204,7 @@ public class StompClientLib: NSObject, SRWebSocketDelegate {
         if let json = CFHTTPMessageCopyAllHeaderFields(webSocket.receivedHTTPHeaders)?.takeUnretainedValue() as? [String:Any] {
             if let delegate = delegate {
                 DispatchQueue.main.async(execute: {
-                    delegate.websocketDidConnect(header: json)
+                    delegate.StompClientDidOpen(client: self, header: json)
                 })
             }
         }


### PR DESCRIPTION
Hi.

In order to return a specific custom value to receiveHTTPHeader when the websocket is open, 
a delegate that receives the receiveHTTPHeader data callback has been added.

Please review, and if there is a part that needs to be modified or reflected, 
such as function name or logic, please contact us.

Thank you. 