### PR TITLE
stompClientDidConnect callback delegate, add receiveHTTPHeader

### DIFF
--- a/StompClientLibExample/StompClientLibExample/ViewController.swift
+++ b/StompClientLibExample/StompClientLibExample/ViewController.swift
@@ -81,7 +81,7 @@ class ViewController: UIViewController, StompClientLibDelegate {
         socketClient.openSocketWithURLRequest(request: NSURLRequest(url: url as URL) , delegate: self as StompClientLibDelegate)
     }
     
-    func stompClientDidConnect(client: StompClientLib!) {
+    func stompClientDidConnect(client: StompClientLib!, withHeader: [String : Any]?) {
         let topic = self.topic
         print("Socket is Connected : \(topic)")
         socketClient.subscribe(destination: topic)


### PR DESCRIPTION
Hi.
When stompConnect is completed, the modification work has been made so that HTTP Header information can be optionally delivered through delegate.

Please review and comment.

Thank you.